### PR TITLE
Extract alarm results from action results

### DIFF
--- a/meteoroid_cli/meteoroid/v1/result.py
+++ b/meteoroid_cli/meteoroid/v1/result.py
@@ -46,7 +46,8 @@ class ResultList(Lister):
             for index in range(len(results)):
                 results[index].pop("annotations")
         if len(results) > 0:
-            columns = results[0].keys()
-            data = [x.values() for x in results]
+            max_len = len(max(results, key=lambda x: len(x)))
+            columns = [x.keys() for x in results if max_len == len(x)][0]
+            data = [x.values() for x in results if max_len == len(x)]
             return columns, data
         return (), ()


### PR DESCRIPTION
I have temporarily fixed error of results. 
To my mind, The results should be supported to serializer in the Meteoroid core. Then, should fix fields length of results.